### PR TITLE
Modify Student Pages Serving Priority

### DIFF
--- a/authorizer.py
+++ b/authorizer.py
@@ -205,10 +205,12 @@ class Authorizer(object):
              institution, session, self.student_entity, serving_rules)
     # When a student is listed under multiple serving rules,
     # return the start page with highest priority.
-    if "schedule" in page_types:
-      return "schedule"
     if "final" in page_types:
       return "postregistration"
+    if "schedule" in page_types:
+      return "schedule"
+    if "materials" in page_types:
+      return "preregistration"
     else:
       return "preregistration"
 


### PR DESCRIPTION
modified the code regarding student pages serving priority. The logic is:
- go to "Step 3 - Final Schedule" if student has access 
- otherwise go to "Step 2 - Register" if student has access 
- otherwise go to "Step 1 - Materials" if student has access